### PR TITLE
Add animation support

### DIFF
--- a/signatures/simple.js
+++ b/signatures/simple.js
@@ -29,7 +29,7 @@ module.exports = [
     },
     "property": {
       "type": "Identifier",
-      "name": /^(controller|directive|filter|service|factory|decorator|provider)$/
+      "name": /^(controller|directive|filter|service|factory|decorator|provider|animation)$/
     }
   },
   "arguments": [


### PR DESCRIPTION
Allow the AST to pick up `animation`s and annotate them appropriately, e.g.

``` javascript
module.animation('animation-fade-enter', function($jq, _) {...});
```

becomes

``` javascript
module.animation('animation-fade-enter', ['$jq', '_', function($jq, _) {}]);
```

Tested this locally with `ngMin` - sorry, not sure if there are other tests to perform.
