### PR TITLE
Added support for CoffeeScript class syntax

### DIFF
--- a/passes/class.js
+++ b/passes/class.js
@@ -1,0 +1,73 @@
+// annotate coffeescript class definitions
+
+var deepApply = require('../lib/deep-apply');
+
+var classAnnotatorPass = module.exports = {};
+classAnnotatorPass.name = 'angular:annotator:class';
+classAnnotatorPass.prereqs = [
+  'angular:annotator:mark'
+];
+
+classAnnotatorPass.run = function (ast, info) {
+  var className;
+  deepApply(ast, [{
+    "type": "CallExpression",
+    "callee": {
+      "type": "MemberExpression",
+      "object": {
+        "ngModule": true
+      },
+      "property": {
+      "type": "Identifier",
+      "name": /^(controller|service|factory)$/
+      }
+    }
+  }], function (classChunk) {
+    deepApply(classChunk, [{
+      "type": "AssignmentExpression",
+      "operator": "=",
+      "left": {
+        "type": "Identifier"
+      },
+      "right": {
+        "type": "CallExpression",
+        "callee": {
+          "type": "FunctionExpression",
+          "params": []
+        }
+      }
+    }], function (assignChunk) {
+
+      className = assignChunk.left.name;
+
+      deepApply(assignChunk, [{
+        "type": "FunctionDeclaration",
+        "id": {
+          "type": "Identifier",
+          "name": className
+        }
+      }], function (funcChunk) {
+
+        if (funcChunk.params && funcChunk.params.length > 0)
+        {
+          var newParam = {
+            type: 'ArrayExpression',
+            elements: []
+          };
+
+          funcChunk.params.forEach(function (param) {
+            newParam.elements.push({
+              "type": "Literal",
+              "value": param.name
+            });
+          });
+
+          newParam.elements.push(assignChunk);
+
+          classChunk.arguments[1] = newParam;
+
+        }
+      });
+    });
+  });
+};


### PR DESCRIPTION
CoffeeScript classes can be useful in AngularJS applications when writing factories, services and controllers (using the new 'Controller as' syntax). More here: http://alxhill.com/blog/articles/angular-coffeescript/

Here's one way to use coffee classes in Angular:

``` coffeescript
angular.module('app').service 'TestService', class TestService
 constructor: ($scope, $timeout, $http) ->
```

This is converted into the following JavaScript.

``` javascript
var TestService;

angular.module('app').service('TestService', TestService = (function() {
  function TestService($scope, $timeout, $http) {}

  return TestService;

})());
```

Of course, ngmin fails for this, so it's necessary to add in the $inject array manually.

This pull request allows ngmin to detect the JavaScript above and convert it into

``` javascript
var TestService;

angular.module('app').service('TestService', ['$scope', '$timeout', '$http', TestService = (function() {
  function TestService($scope, $timeout, $http) {}

  return TestService;

})()]);
```

I've tested this with a few different cases and it seems to be reliable.
